### PR TITLE
Don't create output directory if no output types are configured

### DIFF
--- a/src/LineCount.ts
+++ b/src/LineCount.ts
@@ -327,6 +327,12 @@ export default class LineCount {
         }
     }
 
+    private shouldCreateOutPath() {
+        if (this.outtype.txt || this.outtype.json || this.outtype.csv || this.outtype.md) {
+            return !fs.existsSync(this.outpath);
+        }
+        return false;
+    }
 
     private outFile(total: any) {
         this.out.show();
@@ -348,7 +354,7 @@ export default class LineCount {
             }
         }
 
-        if (!fs.existsSync(this.outpath)) {
+        if (this.shouldCreateOutPath()) {
             fs.mkdirSync(this.outpath);
         }
 


### PR DESCRIPTION
With the following settings an empty output directory is created:

```json
"LineCount.output": {
	"txt": false,
	"json": false,
	"csv": false,
	"md": false,
	"outdir": "out"
},
```

This change will only create the output directory if one or more output type is true.